### PR TITLE
feat(stream watchers) disable double chunking

### DIFF
--- a/server/v2/get_handler.go
+++ b/server/v2/get_handler.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 	"strconv"
 
@@ -74,11 +73,9 @@ func handleWatch(key string, recursive, stream bool, waitIndex string, w http.Re
 		// watcher hub will not help to remove stream watcher
 		// so we need to remove here
 		defer watcher.Remove()
-		chunkWriter := httputil.NewChunkedWriter(w)
 		for {
 			select {
 			case <-closeChan:
-				chunkWriter.Close()
 				return nil
 			case event, ok := <-watcher.EventChan:
 				if !ok {
@@ -89,7 +86,7 @@ func handleWatch(key string, recursive, stream bool, waitIndex string, w http.Re
 				}
 
 				b, _ := json.Marshal(event)
-				_, err := chunkWriter.Write(b)
+				_, err := w.Write(b)
 				if err != nil {
 					return nil
 				}


### PR DESCRIPTION
Both golang http client and curl command does auto dechunking so I have to test it with telnet. Here is a sample output after this commit:

```
cenk@tardis ~ (master) $ telnet 127.0.0.1 4001
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
GET /v2/keys/a?wait=true&stream=true HTTP/1.1

HTTP/1.1 200 OK
Content-Type: application/json
X-Etcd-Index: 1203
X-Raft-Index: 9698
X-Raft-Term: 4
Date: Fri, 10 Jan 2014 13:08:26 GMT
Transfer-Encoding: chunked

a6
{"action":"set","node":{"key":"/a","value":"3","modifiedIndex":1204,"createdIndex":1204},"prevNode":{"key":"/a","value":"1","modifiedIndex":1203,"createdIndex":1203}}
a6
{"action":"set","node":{"key":"/a","value":"4","modifiedIndex":1205,"createdIndex":1205},"prevNode":{"key":"/a","value":"3","modifiedIndex":1204,"createdIndex":1204}}
^]
telnet> q
Connection closed.
```
